### PR TITLE
improve macros

### DIFF
--- a/z_osmf/Cargo.toml
+++ b/z_osmf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "z_osmf"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Billy McGee <william.j.mcgee3@gmail.com>"]
 description = "The Rust z/OSMF Client"
@@ -36,7 +36,7 @@ serde_json = { version = "1.0", optional = true }
 thiserror = "1.0"
 tokio = { version = "1.32", default-features = false }
 
-z_osmf_macros = { version = "0.9", path = "../z_osmf_macros" }
+z_osmf_macros = { version = "0.10", path = "../z_osmf_macros" }
 
 
 [dev-dependencies]

--- a/z_osmf/src/datasets.rs
+++ b/z_osmf/src/datasets.rs
@@ -458,13 +458,27 @@ impl From<Enqueue> for HeaderValue {
     }
 }
 
-pub(crate) fn get_session_ref(response: &reqwest::Response) -> Result<Option<Box<str>>, Error> {
+fn get_member(value: &Option<Box<str>>) -> String {
+    value
+        .as_ref()
+        .map(|v| format!("({})", v))
+        .unwrap_or("".to_string())
+}
+
+fn get_session_ref(response: &reqwest::Response) -> Result<Option<Box<str>>, Error> {
     Ok(response
         .headers()
         .get("X-IBM-Session-Ref")
         .map(|v| v.to_str())
         .transpose()?
         .map(|v| v.into()))
+}
+
+fn get_volume(value: &Option<Box<str>>) -> String {
+    value
+        .as_ref()
+        .map(|v| format!("/-({})", v))
+        .unwrap_or("".to_string())
 }
 
 #[cfg(test)]

--- a/z_osmf/src/datasets/copy_file.rs
+++ b/z_osmf/src/datasets/copy_file.rs
@@ -7,8 +7,10 @@ use z_osmf_macros::Endpoint;
 use crate::convert::TryFromResponse;
 use crate::ClientCore;
 
+use super::{get_member, get_volume};
+
 #[derive(Clone, Debug, Endpoint)]
-#[endpoint(method = put, path = "/zosmf/restfiles/ds/{volume}{to_dataset}{to_member}")]
+#[endpoint(method = put, path = "/zosmf/restfiles/ds{volume}/{to_dataset}{to_member}")]
 pub struct CopyFileBuilder<T>
 where
     T: TryFromResponse,
@@ -17,18 +19,17 @@ where
 
     #[endpoint(builder_fn = build_body)]
     from_path: Box<str>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     file_type: Option<FileType>,
-    #[endpoint(optional, path, setter_fn = set_volume)]
-    volume: Box<str>,
+    #[endpoint(path, builder_fn = build_volume)]
+    volume: Option<Box<str>>,
     #[endpoint(path)]
     to_dataset: Box<str>,
-    #[endpoint(optional, path, setter_fn = set_to_member)]
-    to_member: Box<str>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(path, builder_fn = build_to_member)]
+    to_member: Option<Box<str>>,
+    #[endpoint(skip_builder)]
     replace: Option<bool>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -72,20 +73,16 @@ where
     })
 }
 
-fn set_to_member<T>(mut builder: CopyFileBuilder<T>, value: Box<str>) -> CopyFileBuilder<T>
+fn build_to_member<T>(builder: &CopyFileBuilder<T>) -> String
 where
     T: TryFromResponse,
 {
-    builder.to_member = format!("({})", value).into();
-
-    builder
+    get_member(&builder.to_member)
 }
 
-fn set_volume<T>(mut builder: CopyFileBuilder<T>, value: Box<str>) -> CopyFileBuilder<T>
+fn build_volume<T>(builder: &CopyFileBuilder<T>) -> String
 where
     T: TryFromResponse,
 {
-    builder.volume = format!("-({})/", value).into();
-
-    builder
+    get_volume(&builder.volume)
 }

--- a/z_osmf/src/datasets/create.rs
+++ b/z_osmf/src/datasets/create.rs
@@ -18,40 +18,39 @@ where
     #[endpoint(path)]
     dataset_name: Box<str>,
 
-    #[endpoint(optional, builder_fn = build_body)]
+    #[endpoint(builder_fn = build_body)]
     volume: Option<Box<str>>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     device_type: Option<Box<str>>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     organization: Option<Box<str>>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     space_allocation_unit: Option<Box<str>>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     primary_space: Option<i32>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     secondary_space: Option<i32>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     directory_blocks: Option<i32>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     average_block_size: Option<i32>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     record_format: Option<Box<str>>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     block_size: Option<i32>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     record_length: Option<i32>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     storage_class: Option<Box<str>>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     management_class: Option<Box<str>>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     data_class: Option<Box<str>>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     dataset_type: Option<Box<str>>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     model_dataset: Option<Box<str>>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 

--- a/z_osmf/src/datasets/list.rs
+++ b/z_osmf/src/datasets/list.rs
@@ -180,18 +180,17 @@ where
 
     #[endpoint(query = "dslevel")]
     name_pattern: Box<str>,
-    #[endpoint(optional, query = "volser")]
+    #[endpoint(query = "volser")]
     volume: Option<Box<str>>,
-    #[endpoint(optional, query = "start")]
+    #[endpoint(query = "start")]
     start: Option<Box<str>>,
-    #[endpoint(optional, header = "X-IBM-Max-Items")]
+    #[endpoint(header = "X-IBM-Max-Items")]
     max_items: Option<i32>,
-    #[endpoint(optional, skip_setter, builder_fn = build_attributes)]
+    #[endpoint(skip_setter, builder_fn = build_attributes)]
     attributes: Option<Attrs>,
-    #[endpoint(optional, skip_builder)]
-    include_total: bool,
+    #[endpoint(skip_builder)]
+    include_total: Option<bool>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -281,16 +280,20 @@ where
     T: TryFromResponse,
 {
     match (list_builder.attributes, list_builder.include_total) {
-        (None, false) => request_builder,
-        (None, true) => request_builder.header("X-IBM-Attributes", "dsname,total"),
+        (None, Some(true)) => request_builder.header("X-IBM-Attributes", "dsname,total"),
         (Some(attributes), include_total) => request_builder.header(
             "X-IBM-Attributes",
             format!(
                 "{}{}",
                 attributes,
-                if include_total { ",total" } else { "" }
+                if include_total == Some(true) {
+                    ",total"
+                } else {
+                    ""
+                }
             ),
         ),
+        _ => request_builder,
     }
 }
 

--- a/z_osmf/src/datasets/members.rs
+++ b/z_osmf/src/datasets/members.rs
@@ -119,20 +119,19 @@ where
 
     #[endpoint(path)]
     dataset_name: Box<str>,
-    #[endpoint(optional, query = "start")]
+    #[endpoint(query = "start")]
     start: Option<Box<str>>,
-    #[endpoint(optional, query = "pattern")]
+    #[endpoint(query = "pattern")]
     pattern: Option<Box<str>>,
-    #[endpoint(optional, header = "X-IBM-Max-Items")]
+    #[endpoint(header = "X-IBM-Max-Items")]
     max_items: Option<i32>,
-    #[endpoint(optional, skip_setter, builder_fn = build_attributes)]
+    #[endpoint(skip_setter, builder_fn = build_attributes)]
     attributes: Option<Attrs>,
-    #[endpoint(optional, skip_builder)]
-    include_total: bool,
-    #[endpoint(optional, header = "X-IBM-Migrated-Recall")]
+    #[endpoint(skip_builder)]
+    include_total: Option<bool>,
+    #[endpoint(header = "X-IBM-Migrated-Recall")]
     migrated_recall: Option<MigratedRecall>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -216,12 +215,16 @@ where
     let key = "X-IBM-Attributes";
 
     match (attributes, include_total) {
-        (None, false) => request_builder,
-        (None, true) => request_builder.header(key, "member,total"),
+        (None, Some(true)) => request_builder.header(key, "member,total"),
         (Some(attr), total) => request_builder.header(
             key,
-            format!("{}{}", attr, if *total { ",total" } else { "" }),
+            format!(
+                "{}{}",
+                attr,
+                if *total == Some(true) { ",total" } else { "" }
+            ),
         ),
+        _ => request_builder,
     }
 }
 

--- a/z_osmf/src/datasets/rename.rs
+++ b/z_osmf/src/datasets/rename.rs
@@ -7,7 +7,7 @@ use z_osmf_macros::Endpoint;
 use crate::convert::TryFromResponse;
 use crate::ClientCore;
 
-use super::Enqueue;
+use super::{get_member, Enqueue};
 
 #[derive(Clone, Debug, Endpoint)]
 #[endpoint(method = put, path = "/zosmf/restfiles/ds/{to_dataset}{to_member}")]
@@ -21,14 +21,13 @@ where
     from_dataset: Box<str>,
     #[endpoint(path)]
     to_dataset: Box<str>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     from_member: Option<Box<str>>,
-    #[endpoint(optional, path, setter_fn = set_to_member)]
-    to_member: Box<str>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(path, builder_fn = build_to_member)]
+    to_member: Option<Box<str>>,
+    #[endpoint(skip_builder)]
     enqueue: Option<Enqueue>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -65,11 +64,9 @@ where
     })
 }
 
-fn set_to_member<T>(mut builder: RenameBuilder<T>, value: Box<str>) -> RenameBuilder<T>
+fn build_to_member<T>(builder: &RenameBuilder<T>) -> String
 where
     T: TryFromResponse,
 {
-    builder.to_member = format!("({})", value).into();
-
-    builder
+    get_member(&builder.to_member)
 }

--- a/z_osmf/src/files/copy.rs
+++ b/z_osmf/src/files/copy.rs
@@ -19,16 +19,15 @@ where
     from_path: Box<str>,
     #[endpoint(path)]
     to_path: Box<str>,
-    #[endpoint(optional, skip_builder)]
-    overwrite: bool,
-    #[endpoint(optional, skip_builder)]
-    recursive: bool,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
+    overwrite: Option<bool>,
+    #[endpoint(skip_builder)]
+    recursive: Option<bool>,
+    #[endpoint(skip_builder)]
     links: Option<Links>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     preserve: Option<Preserve>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -72,8 +71,8 @@ where
     request_builder.json(&RequestJson {
         request: "copy",
         from: &builder.from_path,
-        overwrite: builder.overwrite,
-        recursive: builder.recursive,
+        overwrite: builder.overwrite == Some(true),
+        recursive: builder.recursive == Some(true),
         links: builder.links,
         preserve: builder.preserve,
     })

--- a/z_osmf/src/files/copy_dataset.rs
+++ b/z_osmf/src/files/copy_dataset.rs
@@ -19,12 +19,11 @@ where
     from_dataset: Box<str>,
     #[endpoint(path)]
     to_path: Box<str>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     from_member: Option<Box<str>>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     dataset_type: Option<DatasetType>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 

--- a/z_osmf/src/files/create.rs
+++ b/z_osmf/src/files/create.rs
@@ -26,12 +26,11 @@ where
     #[endpoint(path)]
     path: Box<str>,
 
-    #[endpoint(optional, builder_fn = build_body)]
+    #[endpoint(builder_fn = build_body)]
     file_type: Option<FileType>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     mode: Option<Box<str>>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 

--- a/z_osmf/src/files/delete.rs
+++ b/z_osmf/src/files/delete.rs
@@ -16,10 +16,9 @@ where
 
     #[endpoint(path)]
     path: Box<str>,
-    #[endpoint(optional, builder_fn = build_recursive)]
-    recursive: bool,
+    #[endpoint(builder_fn = build_recursive)]
+    recursive: Option<bool>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -31,8 +30,8 @@ where
     T: TryFromResponse,
 {
     match builder.recursive {
-        true => request_builder.header("X-IBM-Option", "recursive"),
-        false => request_builder,
+        Some(true) => request_builder.header("X-IBM-Option", "recursive"),
+        _ => request_builder,
     }
 }
 

--- a/z_osmf/src/files/extra_attributes.rs
+++ b/z_osmf/src/files/extra_attributes.rs
@@ -63,7 +63,7 @@ where
     #[endpoint(path)]
     path: Box<str>,
 
-    #[endpoint(optional, skip_setter, builder_fn = build_body)]
+    #[endpoint(builder_fn = build_body)]
     target_type: PhantomData<T>,
 }
 

--- a/z_osmf/src/files/extra_attributes/reset.rs
+++ b/z_osmf/src/files/extra_attributes/reset.rs
@@ -18,16 +18,15 @@ where
 
     #[endpoint(path)]
     path: Box<str>,
-    #[endpoint(optional, builder_fn = build_body)]
-    apf_authorized: bool,
-    #[endpoint(optional, skip_builder)]
-    shared_library: bool,
-    #[endpoint(optional, skip_builder)]
-    program_controlled: bool,
-    #[endpoint(optional, skip_builder)]
-    shared_address_space: bool,
+    #[endpoint(builder_fn = build_body)]
+    apf_authorized: Option<bool>,
+    #[endpoint(skip_builder)]
+    shared_library: Option<bool>,
+    #[endpoint(skip_builder)]
+    program_controlled: Option<bool>,
+    #[endpoint(skip_builder)]
+    shared_address_space: Option<bool>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -40,16 +39,16 @@ where
 {
     let mut reset = Vec::new();
 
-    if builder.apf_authorized {
+    if builder.apf_authorized == Some(true) {
         reset.push('a');
     }
-    if builder.shared_library {
+    if builder.shared_library == Some(true) {
         reset.push('l');
     }
-    if builder.program_controlled {
+    if builder.program_controlled == Some(true) {
         reset.push('p');
     }
-    if builder.shared_address_space {
+    if builder.shared_address_space == Some(true) {
         reset.push('s');
     }
     let reset = Some(reset.into_iter().collect::<String>().into());

--- a/z_osmf/src/files/extra_attributes/set.rs
+++ b/z_osmf/src/files/extra_attributes/set.rs
@@ -18,16 +18,15 @@ where
 
     #[endpoint(path)]
     path: Box<str>,
-    #[endpoint(optional, builder_fn = build_body)]
-    apf_authorized: bool,
-    #[endpoint(optional, skip_builder)]
-    shared_library: bool,
-    #[endpoint(optional, skip_builder)]
-    program_controlled: bool,
-    #[endpoint(optional, skip_builder)]
-    shared_address_space: bool,
+    #[endpoint(builder_fn = build_body)]
+    apf_authorized: Option<bool>,
+    #[endpoint(skip_builder)]
+    shared_library: Option<bool>,
+    #[endpoint(skip_builder)]
+    program_controlled: Option<bool>,
+    #[endpoint(skip_builder)]
+    shared_address_space: Option<bool>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -40,16 +39,16 @@ where
 {
     let mut set = Vec::new();
 
-    if builder.apf_authorized {
+    if builder.apf_authorized == Some(true) {
         set.push('a');
     }
-    if builder.shared_library {
+    if builder.shared_library == Some(true) {
         set.push('l');
     }
-    if builder.program_controlled {
+    if builder.program_controlled == Some(true) {
         set.push('p');
     }
-    if builder.shared_address_space {
+    if builder.shared_address_space == Some(true) {
         set.push('s');
     }
     let set = Some(set.into_iter().collect::<String>().into());

--- a/z_osmf/src/files/link.rs
+++ b/z_osmf/src/files/link.rs
@@ -21,12 +21,11 @@ where
     target_path: Box<str>,
     #[endpoint(skip_builder)]
     link_type: LinkType,
-    #[endpoint(optional, skip_builder)]
-    recursive: bool,
-    #[endpoint(optional, skip_builder)]
-    force: bool,
+    #[endpoint(skip_builder)]
+    recursive: Option<bool>,
+    #[endpoint(skip_builder)]
+    force: Option<bool>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -58,8 +57,8 @@ where
         request: "link",
         from: &builder.source_path,
         link_type: builder.link_type,
-        recursive: builder.recursive,
-        force: builder.force,
+        recursive: builder.recursive == Some(true),
+        force: builder.force == Some(true),
     })
 }
 

--- a/z_osmf/src/files/list.rs
+++ b/z_osmf/src/files/list.rs
@@ -72,32 +72,31 @@ where
 
     #[endpoint(query = "path")]
     path: Box<str>,
-    #[endpoint(optional, builder_fn = build_lstat)]
-    lstat: bool,
-    #[endpoint(optional, query = "group")]
+    #[endpoint(builder_fn = build_lstat)]
+    lstat: Option<bool>,
+    #[endpoint(query = "group")]
     group: Option<Box<str>>,
-    #[endpoint(optional, query = "mtime")]
+    #[endpoint(query = "mtime")]
     modified_days: Option<Filter<u32>>,
-    #[endpoint(optional, query = "name")]
+    #[endpoint(query = "name")]
     name: Option<Box<str>>,
-    #[endpoint(optional, query = "size")]
+    #[endpoint(query = "size")]
     size: Option<Filter<Size>>,
-    #[endpoint(optional, query = "perm")]
+    #[endpoint(query = "perm")]
     permissions: Option<Box<str>>,
-    #[endpoint(optional, query = "type")]
+    #[endpoint(query = "type")]
     file_type: Option<FileType>,
-    #[endpoint(optional, query = "user")]
+    #[endpoint(query = "user")]
     user: Option<Box<str>>,
-    #[endpoint(optional, query = "depth")]
+    #[endpoint(query = "depth")]
     depth: Option<i32>,
-    #[endpoint(optional, query = "limit")]
+    #[endpoint(query = "limit")]
     limit: Option<i32>,
-    #[endpoint(optional, query = "filesys")]
+    #[endpoint(query = "filesys")]
     file_system: Option<FileSystem>,
-    #[endpoint(optional, query = "symlinks")]
+    #[endpoint(query = "symlinks")]
     symlinks: Option<SymLinks>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -239,8 +238,8 @@ where
     T: TryFromResponse,
 {
     match builder.lstat {
-        true => request_builder.header("X-IBM-Lstat", "true"),
-        false => request_builder,
+        Some(true) => request_builder.header("X-IBM-Lstat", "true"),
+        _ => request_builder,
     }
 }
 

--- a/z_osmf/src/files/mode.rs
+++ b/z_osmf/src/files/mode.rs
@@ -19,12 +19,11 @@ where
     path: Box<str>,
     #[endpoint(builder_fn = build_body)]
     mode: Box<str>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     links: Option<Links>,
-    #[endpoint(optional, skip_builder)]
-    recursive: bool,
+    #[endpoint(skip_builder)]
+    recursive: Option<bool>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -55,7 +54,7 @@ where
         request: "chmod",
         mode: &builder.mode,
         links: builder.links,
-        recursive: builder.recursive,
+        recursive: builder.recursive == Some(true),
     })
 }
 

--- a/z_osmf/src/files/owner.rs
+++ b/z_osmf/src/files/owner.rs
@@ -19,14 +19,13 @@ where
     path: Box<str>,
     #[endpoint(builder_fn = build_body)]
     owner: Box<str>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     group: Option<Box<str>>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     links: Option<Links>,
-    #[endpoint(optional, skip_builder)]
-    recursive: bool,
+    #[endpoint(skip_builder)]
+    recursive: Option<bool>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -60,7 +59,7 @@ where
         owner: &builder.owner,
         group: builder.group.as_deref(),
         links: builder.links,
-        recursive: builder.recursive,
+        recursive: builder.recursive == Some(true),
     })
 }
 

--- a/z_osmf/src/files/read.rs
+++ b/z_osmf/src/files/read.rs
@@ -119,22 +119,21 @@ where
 
     #[endpoint(path)]
     path: Box<str>,
-    #[endpoint(optional, query = "search")]
+    #[endpoint(query = "search")]
     search: Option<Box<str>>,
-    #[endpoint(optional, query = "research")]
+    #[endpoint(query = "research")]
     regex_search: Option<Box<str>>,
-    #[endpoint(optional, builder_fn = build_search_case_sensitive)]
-    search_case_sensitive: bool,
-    #[endpoint(optional, query = "maxreturnsize")]
+    #[endpoint(builder_fn = build_search_case_sensitive)]
+    search_case_sensitive: Option<bool>,
+    #[endpoint(query = "maxreturnsize")]
     search_max_return: Option<i32>,
-    #[endpoint(optional, skip_setter, builder_fn = build_data_type)]
+    #[endpoint(skip_setter, builder_fn = build_data_type)]
     data_type: Option<DataType>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     encoding: Option<Box<str>>,
-    #[endpoint(optional, header = "If-None-Match", skip_setter)]
+    #[endpoint(header = "If-None-Match", skip_setter)]
     etag: Option<Box<str>>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -175,7 +174,7 @@ where
 
     pub fn if_none_match<E>(self, etag: E) -> ReadBuilder<Read<Option<U>>>
     where
-        E: Into<Box<str>>,
+        E: std::fmt::Display,
     {
         ReadBuilder {
             core: self.core,
@@ -186,7 +185,7 @@ where
             search_max_return: self.search_max_return,
             data_type: self.data_type,
             encoding: self.encoding,
-            etag: Some(etag.into()),
+            etag: Some(etag.to_string().into()),
             target_type: PhantomData,
         }
     }
@@ -262,8 +261,8 @@ where
     T: TryFromResponse,
 {
     match builder.search_case_sensitive {
-        true => request_builder.query(&[("insensitive", "false")]),
-        false => request_builder,
+        Some(true) => request_builder.query(&[("insensitive", "false")]),
+        _ => request_builder,
     }
 }
 

--- a/z_osmf/src/files/rename.rs
+++ b/z_osmf/src/files/rename.rs
@@ -19,10 +19,9 @@ where
     from_path: Box<str>,
     #[endpoint(path)]
     to_path: Box<str>,
-    #[endpoint(optional, skip_builder)]
-    overwrite: bool,
+    #[endpoint(skip_builder)]
+    overwrite: Option<bool>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -43,7 +42,7 @@ where
     request_builder.json(&RequestJson {
         request: "move",
         from: &builder.from_path,
-        overwrite: builder.overwrite,
+        overwrite: builder.overwrite == Some(true),
     })
 }
 

--- a/z_osmf/src/files/tags.rs
+++ b/z_osmf/src/files/tags.rs
@@ -64,10 +64,9 @@ where
 
     #[endpoint(path)]
     path: Box<str>,
-    #[endpoint(optional, builder_fn = build_tags_body)]
-    recursive: bool,
+    #[endpoint(builder_fn = build_tags_body)]
+    recursive: Option<bool>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -129,7 +128,7 @@ where
     request_builder.json(&TagsRequestJson {
         request: "chtag",
         action: "list",
-        recursive: builder.recursive,
+        recursive: builder.recursive == Some(true),
     })
 }
 

--- a/z_osmf/src/files/tags/remove.rs
+++ b/z_osmf/src/files/tags/remove.rs
@@ -19,12 +19,11 @@ where
 
     #[endpoint(path)]
     path: Box<str>,
-    #[endpoint(optional, builder_fn = build_body)]
+    #[endpoint(builder_fn = build_body)]
     links: Option<Links>,
-    #[endpoint(optional, skip_builder)]
-    recursive: bool,
+    #[endpoint(skip_builder)]
+    recursive: Option<bool>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -47,7 +46,7 @@ where
         request: "chtag",
         action: "remove",
         links: builder.links,
-        recursive: builder.recursive,
+        recursive: builder.recursive == Some(true),
     })
 }
 

--- a/z_osmf/src/files/tags/set.rs
+++ b/z_osmf/src/files/tags/set.rs
@@ -19,16 +19,15 @@ where
 
     #[endpoint(path)]
     path: Box<str>,
-    #[endpoint(optional, builder_fn = build_body)]
+    #[endpoint(builder_fn = build_body)]
     tag_type: Option<TagType>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     code_set: Option<Box<str>>,
-    #[endpoint(optional, skip_builder)]
+    #[endpoint(skip_builder)]
     links: Option<Links>,
-    #[endpoint(optional, skip_builder)]
-    recursive: bool,
+    #[endpoint(skip_builder)]
+    recursive: Option<bool>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -58,7 +57,7 @@ where
         tag_type: builder.tag_type,
         codeset: builder.code_set.as_deref(),
         links: builder.links,
-        recursive: builder.recursive,
+        recursive: builder.recursive == Some(true),
     })
 }
 

--- a/z_osmf/src/files/unlink.rs
+++ b/z_osmf/src/files/unlink.rs
@@ -18,7 +18,7 @@ where
     #[endpoint(path)]
     path: Box<str>,
 
-    #[endpoint(optional, skip_setter, builder_fn = build_body)]
+    #[endpoint(builder_fn = build_body)]
     target_type: PhantomData<T>,
 }
 

--- a/z_osmf/src/info.rs
+++ b/z_osmf/src/info.rs
@@ -42,6 +42,5 @@ where
 {
     core: Arc<ClientCore>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }

--- a/z_osmf/src/jobs.rs
+++ b/z_osmf/src/jobs.rs
@@ -453,6 +453,13 @@ pub struct Step {
     abend_reason_code: Option<Box<str>>,
 }
 
+fn get_subsystem(value: &Option<Box<str>>) -> String {
+    value
+        .as_ref()
+        .map(|v| format!("/-{}", v))
+        .unwrap_or("".to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/z_osmf/src/jobs/files.rs
+++ b/z_osmf/src/jobs/files.rs
@@ -11,7 +11,7 @@ use z_osmf_macros::{Endpoint, Getters};
 use crate::convert::TryFromResponse;
 use crate::ClientCore;
 
-use super::Identifier;
+use super::{get_subsystem, Identifier};
 
 #[derive(Clone, Debug, Deserialize, Eq, Getters, Hash, PartialEq, Serialize)]
 pub struct JobFiles {
@@ -57,30 +57,24 @@ pub struct JobFile {
 }
 
 #[derive(Clone, Debug, Endpoint)]
-#[endpoint(method = get, path = "/zosmf/restjobs/jobs/{subsystem}{identifier}/files")]
+#[endpoint(method = get, path = "/zosmf/restjobs/jobs{subsystem}/{identifier}/files")]
 pub struct JobFilesBuilder<T>
 where
     T: TryFromResponse,
 {
     core: Arc<ClientCore>,
 
-    #[endpoint(optional, path, setter_fn = set_job_files_subsystem)]
-    subsystem: Box<str>,
+    #[endpoint(path, builder_fn = build_subsystem)]
+    subsystem: Option<Box<str>>,
     #[endpoint(path)]
     identifier: Identifier,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
-fn set_job_files_subsystem<T>(
-    mut builder: JobFilesBuilder<T>,
-    value: Box<str>,
-) -> JobFilesBuilder<T>
+fn build_subsystem<T>(builder: &JobFilesBuilder<T>) -> String
 where
     T: TryFromResponse,
 {
-    builder.subsystem = format!("-{}/", value).into();
-
-    builder
+    get_subsystem(&builder.subsystem)
 }

--- a/z_osmf/src/variables/create.rs
+++ b/z_osmf/src/variables/create.rs
@@ -91,7 +91,6 @@ where
     #[endpoint(builder_fn = build_body)]
     new_variables: Box<[NewVariable]>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 

--- a/z_osmf/src/variables/delete.rs
+++ b/z_osmf/src/variables/delete.rs
@@ -21,7 +21,6 @@ where
     #[endpoint(builder_fn = build_body)]
     variable_names: Box<[String]>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 

--- a/z_osmf/src/variables/export.rs
+++ b/z_osmf/src/variables/export.rs
@@ -21,10 +21,8 @@ where
     system: Box<str>,
     #[endpoint(builder_fn = build_body)]
     path: Box<str>,
-    #[endpoint(optional)]
     overwrite: Option<bool>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 

--- a/z_osmf/src/variables/import.rs
+++ b/z_osmf/src/variables/import.rs
@@ -22,7 +22,6 @@ where
     #[endpoint(builder_fn = build_body)]
     path: Box<str>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 

--- a/z_osmf/src/variables/symbols.rs
+++ b/z_osmf/src/variables/symbols.rs
@@ -42,10 +42,9 @@ where
 {
     core: Arc<ClientCore>,
 
-    #[endpoint(optional, skip_setter, builder_fn = build_names)]
-    names: Vec<String>,
+    #[endpoint(skip_setter, builder_fn = build_names)]
+    names: Option<Vec<String>>,
 
-    #[endpoint(optional, skip_setter, skip_builder)]
     target_type: PhantomData<T>,
 }
 
@@ -58,7 +57,10 @@ where
         V: ToString,
     {
         let mut new = self;
-        new.names.push(value.to_string());
+        match new.names {
+            Some(ref mut names) => names.push(value.to_string()),
+            None => new.names = Some(vec![value.to_string()]),
+        }
 
         new
     }
@@ -68,7 +70,10 @@ where
         V: ToString,
     {
         let mut new = self;
-        new.names.extend(value.iter().map(|v| v.to_string()));
+        match new.names {
+            Some(ref mut names) => names.extend(value.iter().map(|v| v.to_string())),
+            None => new.names = Some(value.iter().map(|v| v.to_string()).collect()),
+        }
 
         new
     }

--- a/z_osmf_macros/Cargo.toml
+++ b/z_osmf_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "z_osmf_macros"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 authors = ["Billy McGee <william.j.mcgee3@gmail.com>"]
 description = "Macros used by z_osmf"

--- a/z_osmf_macros/src/getter.rs
+++ b/z_osmf_macros/src/getter.rs
@@ -1,9 +1,36 @@
 use darling::util::Ignored;
 use darling::{FromDeriveInput, FromField};
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote, ToTokens};
 
-use crate::utils::*;
+use crate::utils::{extract_optional_type, is_option};
+
+impl From<Getter> for proc_macro::TokenStream {
+    fn from(value: Getter) -> Self {
+        let Getter {
+            ident, generics, ..
+        } = &value;
+
+        let (impl_, ty, where_clause) = generics.split_for_impl();
+
+        let getters = value
+            .data
+            .as_ref()
+            .take_struct()
+            .unwrap()
+            .fields
+            .iter()
+            .map(|f| f.getter())
+            .collect::<Vec<_>>();
+
+        quote! {
+            impl #impl_ #ident #ty #where_clause {
+                #( #getters )*
+            }
+        }
+        .into()
+    }
+}
 
 #[derive(FromDeriveInput)]
 #[darling(attributes(getter), supports(struct_named))]
@@ -11,60 +38,6 @@ pub(crate) struct Getter {
     pub ident: syn::Ident,
     pub generics: syn::Generics,
     data: darling::ast::Data<Ignored, GetterField>,
-}
-
-impl Getter {
-    pub(crate) fn get_getters(&self) -> Vec<TokenStream> {
-        match &self.data {
-            darling::ast::Data::Struct(fields) => fields
-                .iter()
-                .filter(|f| !f.skip)
-                .map(|f| {
-                    let GetterField {
-                        ident, ty, copy, ..
-                    } = f;
-                    if *copy {
-                        quote! {
-                            pub fn #ident(&self) -> #ty {
-                                self.#ident
-                            }
-                        }
-                    } else if let Some(ty) = extract_optional_type(ty) {
-                        if let Some(ty) = extract_box_type(&ty) {
-                            quote! {
-                                pub fn #ident(&self) -> Option<&#ty> {
-                                    self.#ident.as_deref()
-                                }
-                            }
-                        } else {
-                            let ty = vec_to_slice_type(ty);
-
-                            quote! {
-                                pub fn #ident(&self) -> Option<&#ty> {
-                                    self.#ident.as_ref()
-                                }
-                            }
-                        }
-                    } else if let Some(ty) = extract_box_type(ty) {
-                        quote! {
-                            pub fn #ident(&self) -> &#ty {
-                                &self.#ident
-                            }
-                        }
-                    } else {
-                        let ty = vec_to_slice_type(ty.clone());
-
-                        quote! {
-                            pub fn #ident(&self) -> &#ty {
-                                &self.#ident
-                            }
-                        }
-                    }
-                })
-                .collect(),
-            _ => panic!(),
-        }
-    }
 }
 
 #[derive(FromField)]
@@ -77,4 +50,125 @@ pub(crate) struct GetterField {
     skip: bool,
     #[darling(default)]
     copy: bool,
+}
+
+impl GetterField {
+    fn getter(&self) -> Option<TokenStream> {
+        match self {
+            GetterField { skip: true, .. } => None,
+            GetterField {
+                copy: true,
+                ident: Some(ident),
+                ty,
+                ..
+            } => Some(quote! {
+                pub fn #ident(&self) -> #ty {
+                    self.#ident
+                }
+            }),
+            GetterField {
+                ident: Some(ident),
+                ty,
+                ..
+            } if ty
+                .to_token_stream()
+                .to_string()
+                .starts_with("Option < Box < ") =>
+            {
+                let ty = extract_box_type(&extract_optional_type(ty).unwrap()).unwrap();
+
+                Some(quote! {
+                    pub fn #ident(&self) -> Option<&#ty> {
+                        self.#ident.as_deref()
+                    }
+                })
+            }
+            GetterField {
+                ident: Some(ident),
+                ty,
+                ..
+            } if is_option(ty) => {
+                let ty = vec_to_slice_type(&extract_optional_type(ty).unwrap());
+
+                Some(quote! {
+                    pub fn #ident(&self) -> Option<&#ty> {
+                        self.#ident.as_ref()
+                    }
+                })
+            }
+            GetterField {
+                ident: Some(ident),
+                ty,
+                ..
+            } if is_box(ty) => {
+                let ty = extract_box_type(ty).unwrap();
+
+                Some(quote! {
+                    pub fn #ident(&self) -> &#ty {
+                        &self.#ident
+                    }
+                })
+            }
+            GetterField {
+                ident: Some(ident),
+                ty,
+                ..
+            } => {
+                let ty = vec_to_slice_type(ty);
+
+                Some(quote! {
+                    pub fn #ident(&self) -> &#ty {
+                        &self.#ident
+                    }
+                })
+            }
+            _ => None,
+        }
+    }
+}
+
+fn extract_box_type(ty: &syn::Type) -> Option<syn::Type> {
+    if let syn::Type::Path(type_path) = &ty {
+        if let Some(path_segment) = type_path.path.segments.first() {
+            if is_box(ty) {
+                if let syn::PathArguments::AngleBracketed(angle_bracketed) = &path_segment.arguments
+                {
+                    let tokens = angle_bracketed.args.first().unwrap().to_token_stream();
+                    let new_ty = syn::parse::<syn::Type>(tokens.into()).unwrap();
+
+                    return Some(new_ty);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn is_box(ty: &syn::Type) -> bool {
+    if let syn::Type::Path(type_path) = &ty {
+        if let Some(path_segment) = type_path.path.segments.first() {
+            return path_segment.ident == format_ident!("{}", "Box");
+        }
+    }
+
+    false
+}
+
+fn vec_to_slice_type(ty: &syn::Type) -> syn::Type {
+    if let syn::Type::Path(type_path) = &ty {
+        if let Some(path_segment) = type_path.path.segments.first() {
+            if path_segment.ident == format_ident!("{}", "Vec") {
+                if let syn::PathArguments::AngleBracketed(angle_bracketed) = &path_segment.arguments
+                {
+                    let tokens = angle_bracketed.args.first().unwrap().to_token_stream();
+                    let new_ty = syn::parse::<syn::Type>(quote! {[#tokens]}.into()).unwrap();
+
+                    return new_ty;
+                }
+            }
+        }
+    }
+
+    ty.clone()
 }

--- a/z_osmf_macros/src/lib.rs
+++ b/z_osmf_macros/src/lib.rs
@@ -5,45 +5,17 @@ mod getter;
 mod utils;
 
 use darling::FromDeriveInput;
-use getter::Getter;
 use proc_macro::TokenStream;
-use quote::quote;
 
 use self::endpoint::Endpoint;
+use self::getter::Getter;
 
 #[proc_macro_derive(Endpoint, attributes(endpoint))]
 pub fn derive_endpoint(input: TokenStream) -> TokenStream {
     let input = &syn::parse_macro_input!(input as syn::DeriveInput);
     let endpoint = Endpoint::from_derive_input(input).unwrap();
 
-    let Endpoint {
-        ref ident,
-        ref generics,
-        ..
-    } = &endpoint;
-
-    let (impl_, ty, where_clause) = generics.split_for_impl();
-
-    let new_fn = endpoint.new_fn();
-    let setter_fns = endpoint.setter_fns();
-    let get_response_fn = endpoint.get_response_fn();
-
-    quote! {
-        impl #impl_ #ident #ty #where_clause {
-            #new_fn
-
-            #( #setter_fns )*
-
-            #get_response_fn
-
-            pub async fn build(self) -> Result<T, crate::error::Error> {
-                use crate::convert::TryIntoTarget;
-
-                self.get_response().await?.try_into_target().await
-            }
-        }
-    }
-    .into()
+    endpoint.into()
 }
 
 #[proc_macro_derive(Getters, attributes(getter))]
@@ -51,18 +23,5 @@ pub fn derive_getters(input: TokenStream) -> TokenStream {
     let input = &syn::parse_macro_input!(input as syn::DeriveInput);
     let getter = Getter::from_derive_input(input).unwrap();
 
-    let Getter {
-        ident, generics, ..
-    } = &getter;
-
-    let (impl_, ty, where_clause) = generics.split_for_impl();
-
-    let getters = getter.get_getters();
-
-    quote! {
-        impl #impl_ #ident #ty #where_clause {
-            #( #getters )*
-        }
-    }
-    .into()
+    getter.into()
 }

--- a/z_osmf_macros/src/utils.rs
+++ b/z_osmf_macros/src/utils.rs
@@ -1,27 +1,9 @@
-use quote::{format_ident, quote, ToTokens};
-
-pub(crate) fn extract_box_type(ty: &syn::Type) -> Option<syn::Type> {
-    if let syn::Type::Path(type_path) = &ty {
-        if let Some(path_segment) = type_path.path.segments.first() {
-            if path_segment.ident == format_ident!("{}", "Box") {
-                if let syn::PathArguments::AngleBracketed(angle_bracketed) = &path_segment.arguments
-                {
-                    let tokens = angle_bracketed.args.first().unwrap().to_token_stream();
-                    let new_ty = syn::parse::<syn::Type>(tokens.into()).unwrap();
-
-                    return Some(new_ty);
-                }
-            }
-        }
-    }
-
-    None
-}
+use quote::{format_ident, ToTokens};
 
 pub(crate) fn extract_optional_type(ty: &syn::Type) -> Option<syn::Type> {
     if let syn::Type::Path(type_path) = &ty {
         if let Some(path_segment) = type_path.path.segments.first() {
-            if path_segment.ident == format_ident!("{}", "Option") {
+            if is_option(ty) {
                 if let syn::PathArguments::AngleBracketed(angle_bracketed) = &path_segment.arguments
                 {
                     let tokens = angle_bracketed.args.first().unwrap().to_token_stream();
@@ -36,20 +18,22 @@ pub(crate) fn extract_optional_type(ty: &syn::Type) -> Option<syn::Type> {
     None
 }
 
-pub(crate) fn vec_to_slice_type(ty: syn::Type) -> syn::Type {
+pub(crate) fn is_option(ty: &syn::Type) -> bool {
     if let syn::Type::Path(type_path) = &ty {
         if let Some(path_segment) = type_path.path.segments.first() {
-            if path_segment.ident == format_ident!("{}", "Vec") {
-                if let syn::PathArguments::AngleBracketed(angle_bracketed) = &path_segment.arguments
-                {
-                    let tokens = angle_bracketed.args.first().unwrap().to_token_stream();
-                    let new_ty = syn::parse::<syn::Type>(quote! {[#tokens]}.into()).unwrap();
-
-                    return new_ty;
-                }
-            }
+            return path_segment.ident == format_ident!("{}", "Option");
         }
     }
 
-    ty
+    false
+}
+
+pub(crate) fn is_phantom_data(ty: &syn::Type) -> bool {
+    if let syn::Type::Path(type_path) = &ty {
+        if let Some(path_segment) = type_path.path.segments.first() {
+            return path_segment.ident == format_ident!("{}", "PhantomData");
+        }
+    }
+
+    false
 }


### PR DESCRIPTION
- Improve public string-ish argument types
- `Endpoint` macro:
  - Remove `optional` flag, use `Option` type instead
  - Add `builder_fn` support for `path` variables
  - Simplify internals
- `Getter` macro
  - simplify internals